### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ yarn-error.log
 /.idea
 /.vscode
 .DS_Store
+/dist/
+/composer.lock
+/debug.log


### PR DESCRIPTION
adding the following:
/dist/
Excludes the production build directory for Vue

/composer.lock
This is optional; some projects prefer to include composer.lock to lock dependency versions

/debug.log
Excludes any custom log files created during development